### PR TITLE
fix(page): use expected router page event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ function handleActionType(next: Function, action: Object) {
   switch (action.type) {
     case '@@router/INIT_PATH':
     case '@@router/UPDATE_PATH':
-    case '@@router/UPDATE_LOCATION':
+    case '@@router/LOCATION_CHANGE':
     case '@@reduxReactRouter/initRoutes':
     case '@@reduxReactRouter/routerDidChange':
     case '@@reduxReactRouter/replaceRoutes':


### PR DESCRIPTION
@bertrandk I flubbed on the event name. This PR includes the expected event name, as shown in the image here.

<img width="345" alt="screen shot 2016-03-16 at 11 55 37 pm" src="https://cloud.githubusercontent.com/assets/440298/13836884/e0138864-ebd3-11e5-8988-d12db9463f94.png">
