### PR TITLE
fix mapper assignment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ function emit(type: string, fields: Array) {
 }
 
 function createTracker(options = {}) {
-  const mapper = Object.assign({}, { mapper : defaultMapper.mapper }, options.mapper);
+  const mapper = Object.assign({}, { mapper : defaultMapper.mapper }, { mapper: options.mapper });
   return store => next => action => handleAction(store.getState.bind(store), next, action, mapper);
 }
 


### PR DESCRIPTION
This change is needed for the given example to work:

```
import { EventTypes } from 'redux-segment'
const customMapper = {
  mapper: {
    '@@router/CALL_HISTORY_LOCATION': EventTypes.page,
    '@@router/UPDATE_LOCATION': EventTypes.page,
    '@@reduxReactRouter/replaceRoutes': (getState) => {
      return {
        eventType: EventTypes.page,
        eventPayload: {
            name: ActionType.ADD_TODO,
            text: getState().text,
        }
      }
    }
  }
}

const tracker = createTracker(customMapper);
```

Otherwise, you would need
```
const customMapper = {
  mapper: {
    mapper: {...}
  }
};
```