### PR TITLE
add option to replace event name

### DIFF
--- a/src/event/track.js
+++ b/src/event/track.js
@@ -7,9 +7,10 @@ function validateTrackFields(fields: Object, actionType: string) {
 }
 
 function getTrackProperties(fields: Object) {
-  if (!fields.properties) return [ 'event', 'options' ];
+  let temp = ['event'];
+  temp.push(...Object.keys(fields))
 
-  return [ 'event', 'properties', 'options' ];
+  return temp
 }
 
 function extractFields(obj: Object, keys: Array, actionType: string) {

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,9 @@ function emit(type: string, fields: Array, { client }: Object) {
   const currentClient = client();
 
   if (typeof currentClient[type] === 'function') {
+    if (fields[1] && fields[1].action) {
+      fields[0] = fields[1].action;
+    }
     currentClient[type](...fields);
   } else {
     warn(`The analytics client you provided doesn't support ${ type } events.`);


### PR DESCRIPTION
in most of the cases i want to have one action on my redux store that will catch all the analytics events but then in the custom mapper i want to change the name of the action/event from the original one (from my redux store) to another name that will be exposed outside.

for example on my redux store there is only one action called "bla/bla/track_analytics"
then gets action, category, label as eventPayload/properties.
then on the custom tracker replace the "bla/bla/track_analytics" with eventPayload action.