### PR TITLE
Extra semicolon caused "statements are not allowed in ambient contexts" error

### DIFF
--- a/typings/redux-segment.d.ts
+++ b/typings/redux-segment.d.ts
@@ -11,7 +11,7 @@ declare namespace ReduxSegment {
     interface ICustomMapper {
         skipDefaultMapping?: boolean;
         mapper?: any;
-    };
+    }
     /**
      * Creates the tracker middleware for injection like so:
      *  compose(applyMiddleware(thunkMiddleware, loggerMiddleware, trackerMiddleware);


### PR DESCRIPTION
Sorry for the premature PR earlier (#113) :( VSCode didn't throw any errors and played nice with the changes, so I had assumed all was well. But it turns out, the semicolon was extra and caused an `Statements are not allowed in ambient contexts.` error.

Seems to work fine now, though. Currently using it as a module in another project.